### PR TITLE
Ensure `partial` is a `RoaringBitmap32` instance before calling `and`…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -463,7 +463,7 @@ class SynapsD extends EventEmitter {
     // - subtractContextBitmap (subtract the current bitmap from an array of bitmaps)
     // - intersectContextBitmap (intersect the current bitmap with an array of bitmaps)
     // - unionContextBitmap (union the current bitmap with an array of bitmaps)
-    // - xorContextBitmap (xor the current bitmap with an array of bitmaps)
+    // - xorContextBitmap (xor the current bitmap with a array of bitmaps)
     // - invertContextBitmap (invert the current bitmap)
     // - isEmptyContextBitmap (check if the current bitmap is empty)
     // - toArrayContextBitmap (convert the current bitmap to an array of ids)

--- a/src/indexes/bitmaps/index.js
+++ b/src/indexes/bitmaps/index.js
@@ -183,6 +183,9 @@ class BitmapIndex {
             for (const key of positiveKeys) {
                 BitmapIndex._validateKey(key);
                 const bitmap = this.getBitmap(key, true);
+                if (!(bitmap instanceof RoaringBitmap32)) {
+                    throw new TypeError(`Bitmap at key "${key}" is not a RoaringBitmap32 instance`);
+                }
                 // clone the first bitmap so we don't change the original
                 partial = partial.and(bitmap);
             }


### PR DESCRIPTION
… method in `AND` function.

* Add a check to verify if `bitmap` is an instance of `RoaringBitmap32` before calling `and` method in `AND` function in `src/indexes/bitmaps/index.js`
* Fix typo in comment in `src/index.js`