### PR TITLE
Refine data abstraction schemas and add metadata

### DIFF
--- a/src/schemas/abstractions/Document.js
+++ b/src/schemas/abstractions/Document.js
@@ -4,7 +4,7 @@ import BaseDocument, { documentSchema } from '../BaseDocument.js';
 import { z } from 'zod';
 
 const DOCUMENT_SCHEMA_NAME = 'data/abstraction/document';
-const DOCUMENT_SCHEMA_VERSION = '2.0';
+const DOCUMENT_SCHEMA_VERSION = '2.1';
 
 const documentDataSchema = z.object({
     schema: z.string(),

--- a/src/schemas/abstractions/Email.js
+++ b/src/schemas/abstractions/Email.js
@@ -4,7 +4,7 @@ import Document, { documentSchema as baseDocumentSchema } from '../BaseDocument.
 import { z } from 'zod';
 
 const DOCUMENT_SCHEMA_NAME = 'data/abstraction/email';
-const DOCUMENT_SCHEMA_VERSION = '2.0';
+const DOCUMENT_SCHEMA_VERSION = '2.1';
 
 const documentDataSchema = z.object({
     schema: z.string(),

--- a/src/schemas/abstractions/File.js
+++ b/src/schemas/abstractions/File.js
@@ -4,7 +4,7 @@ import Document, { documentSchema as baseDocumentSchema } from '../BaseDocument.
 import { z } from 'zod';
 
 const DOCUMENT_SCHEMA_NAME = 'data/abstraction/file';
-const DOCUMENT_SCHEMA_VERSION = '2.0';
+const DOCUMENT_SCHEMA_VERSION = '2.1';
 
 const documentDataSchema = z.object({
     schema: z.string(),

--- a/src/schemas/abstractions/Note.js
+++ b/src/schemas/abstractions/Note.js
@@ -4,7 +4,7 @@ import Document, { documentSchema } from '../BaseDocument.js';
 import { z } from 'zod';
 
 const DOCUMENT_SCHEMA_NAME = 'data/abstraction/note';
-const DOCUMENT_SCHEMA_VERSION = '2.0';
+const DOCUMENT_SCHEMA_VERSION = '2.1';
 
 const documentDataSchema = z.object({
     schema: z.string(),

--- a/src/schemas/abstractions/Tab.js
+++ b/src/schemas/abstractions/Tab.js
@@ -4,7 +4,7 @@ import Document, { documentSchema } from '../BaseDocument.js';
 import { z } from 'zod';
 
 const DOCUMENT_SCHEMA_NAME = 'data/abstraction/tab';
-const DOCUMENT_SCHEMA_VERSION = '2.0';
+const DOCUMENT_SCHEMA_VERSION = '2.1';
 
 const documentDataSchema = z.object({
     schema: z.string(),

--- a/src/schemas/abstractions/Todo.js
+++ b/src/schemas/abstractions/Todo.js
@@ -4,7 +4,7 @@ import Document, { documentSchema as baseDocumentSchema } from '../BaseDocument.
 import { z } from 'zod';
 
 const DOCUMENT_SCHEMA_NAME = 'data/abstraction/todo';
-const DOCUMENT_SCHEMA_VERSION = '2.0';
+const DOCUMENT_SCHEMA_VERSION = '2.1';
 
 const documentDataSchema = z.object({
     schema: z.string(),


### PR DESCRIPTION
Refactor document metadata to include structured data paths, context, and features, and add utility methods for managing them to improve indexing and redundancy.

This PR implements the first phase of a larger refactor to standardize document metadata for improved indexing, redundancy, and external data location management. It introduces new fields like `contextUUIDs`, `contextPath`, and `features` for better data organization and searchability, and a more robust `dataPaths` structure, along with helper methods for their management. The schema version is bumped to 2.1, with backward compatibility for older `dataPaths` formats.

---

[Open in Web](https://cursor.com/agents?id=bc-cf70bf6b-3426-465e-b5de-bd1a4939dda3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cf70bf6b-3426-465e-b5de-bd1a4939dda3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)