### PR TITLE
Normalize layer names and preserve labels

### DIFF
--- a/src/indexes/bitmaps/index.js
+++ b/src/indexes/bitmaps/index.js
@@ -705,8 +705,12 @@ class BitmapIndex {
             key = key.slice(1);
         }
 
-        // Remove disallowed characters. Allowed: a-z, A-Z, 0-9, underscore, dash, dot, forward slash.
-        key = key.replace(/[^a-zA-Z0-9_\-./]/g, '');
+        // Normalize whitespace and case, then sanitize: allow [a-z0-9._-/]
+        key = String(key)
+            .replace(/\s+/g, '_')
+            .toLowerCase()
+            .replace(/[^a-z0-9_\-./]/g, '_')
+            .replace(/_+/g, '_');
 
         // Collapse multiple slashes to single slashes
         key = key.replace(/\/+/g, '/');

--- a/src/indexes/bitmaps/lib/BitmapCollection.js
+++ b/src/indexes/bitmaps/lib/BitmapCollection.js
@@ -32,7 +32,7 @@ export default class BitmapCollection {
      * Key management
      */
 
-    makeKey(key) {
+	makeKey(key) {
         // If the input key segment is already '/', it refers to the root of this collection.
         // this.keyPrefix (e.g., 'context/') already correctly represents this root path.
         if (key === '/') {
@@ -40,14 +40,17 @@ export default class BitmapCollection {
             return this.keyPrefix;
         }
 
-        // Handle negation prefix before other normalizations
-        const isNegated = key.startsWith('!');
-        let normalizedSegment = isNegated ? key.slice(1) : key;
+		// Handle negation prefix before other normalizations
+		const isNegated = key.startsWith('!');
+		let normalizedSegment = isNegated ? key.slice(1) : key;
 
-        // Sanitize the segment:
-        // Remove disallowed characters. Allowed: a-z, A-Z, 0-9, underscore, dash, dot, forward slash.
-        // Preserves forward slashes
-        normalizedSegment = normalizedSegment.replace(/[^a-zA-Z0-9_\-./]/g, '');
+		// Normalize whitespace and case to ensure consistent keys
+		normalizedSegment = String(normalizedSegment)
+			.replace(/\s+/g, '_')
+			.toLowerCase()
+			// Remove/sanitize disallowed characters. Preserve '/', '.', '-', '_'
+			.replace(/[^a-z0-9_\-./]/g, '_')
+			.replace(/_+/g, '_');
 
         if (normalizedSegment === '') {
             return this.keyPrefix;

--- a/src/schemas/internal/layers/BaseLayer.js
+++ b/src/schemas/internal/layers/BaseLayer.js
@@ -26,9 +26,8 @@ class Layer {
         this.type = options.type ?? 'context';
         this.name = normalizedName;
 
-        // ID: prefer provided id; otherwise use normalized name (stable, human-readable)
-        // Keep Universe/root special-case IDs passed explicitly
-        this.id = options.id ?? normalizedName ?? uuidv4();
+        // ID: prefer provided id; otherwise generate a UUID (do not derive from name)
+        this.id = options.id ?? uuidv4();
 
         // Label: preserve provided label (original user-facing string), else fallback to original name string
         const providedLabel = options.label ?? String(name ?? normalizedName);

--- a/src/schemas/internal/layers/BaseLayer.js
+++ b/src/schemas/internal/layers/BaseLayer.js
@@ -12,19 +12,28 @@ class Layer {
 
         // Default options
         options = {
-            id: uuidv4(),
+            id: undefined,
             type: 'context',
             color: null,
             ...options,
         };
 
-        // TODO: This constructor needs a proper cleanup!
-        this.id = options.id;
+        // Compute normalized name first
+        const normalizedName = this.#sanitizeName(name);
+
+        // Initialize core fields
         this.schemaVersion = options.schemaVersion || '2.0';
         this.type = options.type ?? 'context';
-        this.name = this.#sanitizeName(name);
-        // Always keep label equal to name
-        this.label = this.name;
+        this.name = normalizedName;
+
+        // ID: prefer provided id; otherwise use normalized name (stable, human-readable)
+        // Keep Universe/root special-case IDs passed explicitly
+        this.id = options.id ?? normalizedName ?? uuidv4();
+
+        // Label: preserve provided label (original user-facing string), else fallback to original name string
+        const providedLabel = options.label ?? String(name ?? normalizedName);
+        this.label = this.#sanitizeLabel(providedLabel);
+
         this.description = options.description ? this.#sanitizeDescription(options.description) : 'Canvas layer';
         this.color = options?.color;
         this.lockedBy = options?.lockedBy || [];
@@ -56,8 +65,6 @@ class Layer {
         }
         const sanitized = this.#sanitizeName(name);
         this.name = sanitized;
-        // Keep label equal to name at all times
-        this.label = sanitized;
         return this;
     }
 
@@ -108,17 +115,17 @@ class Layer {
             throw new Error('Name must be a string');
         }
 
-        if (name.length > 32) {
-            throw new Error('Name must be less than 32 characters');
+        if (name.length > 64) {
+            throw new Error('Name must be less than 64 characters');
         }
 
-        // Remove all special characters except underscore, dash, dot and forward slash
-        name = name.replace(/[^a-zA-Z0-9_./-]/g, '_');
-
-        // Convert to lowercase
-        name = name.toLowerCase();
-
-        return name;
+        // Normalize: trim, spaces->underscore, lowercase, allow [a-z0-9._-/], collapse multiple underscores
+        let n = String(name).trim();
+        n = n.replace(/\s+/g, '_');
+        n = n.toLowerCase();
+        n = n.replace(/[^a-z0-9._\/-]/g, '_');
+        n = n.replace(/_+/g, '_');
+        return n;
     }
 
     #sanitizeLabel(label) {
@@ -126,8 +133,8 @@ class Layer {
             throw new Error('Label must be a string');
         }
 
-        if (label.length > 32) {
-            throw new Error('Label must be less than 32 characters');
+        if (label.length > 64) {
+            throw new Error('Label must be less than 64 characters');
         }
 
         return label; //label.replace(/[^a-zA-Z0-9_-]/g, '_');

--- a/src/views/tree/index.js
+++ b/src/views/tree/index.js
@@ -1384,8 +1384,9 @@ class ContextTree extends EventEmitter {
         const segments = normalized.split('/');
         const normalizedSegments = segments.map(segment => {
             if (segment === '') {return '';} // Keep empty segments from split('/')
-            // Lowercase and remove invalid characters
-            return segment.toLowerCase().replace(/[^a-z0-9._-]/g, '');
+            // Replace whitespace with underscore, lowercase and remove invalid characters, collapse underscores
+            let s = segment.replace(/\s+/g, '_').toLowerCase().replace(/[^a-z0-9._-]/g, '_').replace(/_+/g, '_');
+            return s;
         });
 
         // Rejoin, handling potential empty segments if original was just '/' or '//'


### PR DESCRIPTION
Normalize layer names for consistent IDs and introduce separate display labels to support flexible naming and prevent duplicates.

---
<a href="https://cursor.com/background-agent?bcId=bc-be7ae5dd-5c86-48d3-bebd-251791bb9c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be7ae5dd-5c86-48d3-bebd-251791bb9c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

