### PR TITLE
Batch LanceDB delete and backfill operations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1031,12 +1031,10 @@ class SynapsD extends EventEmitter {
         }
 
         // Best-effort Lance cleanup (outside transaction — separate system)
-        for (const { id } of toDelete) {
-            try {
-                await this.#lanceIndex.delete(id);
-            } catch (e) {
-                debug(`deleteMany: Lance delete failed for ${id}: ${e.message}`);
-            }
+        try {
+            await this.#lanceIndex.deleteMany(toDelete.map(({ id }) => id));
+        } catch (e) {
+            debug(`deleteMany: Lance deleteMany failed: ${e.message}`);
         }
 
         for (const { index, id } of toDelete) {

--- a/src/indexes/lance/index.js
+++ b/src/indexes/lance/index.js
@@ -128,6 +128,21 @@ class LanceIndex {
         }
     }
 
+    async deleteMany(docIds) {
+        if (!this.#table || !Array.isArray(docIds) || docIds.length === 0) { return; }
+        const ids = docIds.filter(id => id != null);
+        if (ids.length === 0) { return; }
+        try {
+            await this.#table.delete(`id IN (${ids.join(',')})`);
+        } catch (e) {
+            debug(`LanceIndex deleteMany failed: ${e.message}`);
+            return;
+        }
+        if (this.#bitmapIndex) {
+            try { await this.#bitmapIndex.untickMany([this.#ftsBitmapKey], ids); } catch (_) { }
+        }
+    }
+
     /**
      * BM25 full-text search via LanceDB index.
      * Returns { pageIds, totalCount, error } — caller loads docs from LMDB.
@@ -195,20 +210,18 @@ class LanceIndex {
             if (idsToProcess.length === 0) { return; }
 
             debug(`backfill: skipped ${skipped} already indexed docs, processing ${idsToProcess.length}`);
-            let processed = 0;
+            const docs = [];
             for (const docId of idsToProcess) {
                 try {
                     const docData = await documentsStore.get(docId);
-                    if (docData) {
-                        const doc = parseDoc(docData);
-                        await this.upsert(doc);
-                        processed++;
-                    }
+                    if (docData) { docs.push(parseDoc(docData)); }
                 } catch (e) {
-                    debug(`backfill: failed to upsert doc ${docId}: ${e.message}`);
+                    debug(`backfill: failed to read doc ${docId}: ${e.message}`);
                 }
             }
 
+            await this.addMany(docs);
+            const processed = docs.length;
             debug(`backfill: processed ${processed} documents`);
         } catch (e) {
             debug(`backfill: error ${e.message}`);


### PR DESCRIPTION
- Add LanceIndex.deleteMany() that issues a single SQL IN filter delete
  and batches the bitmap untick, instead of one call per doc
- Update deleteMany() in SynapsD to call lanceIndex.deleteMany() with
  all IDs at once instead of looping lanceIndex.delete()
- Refactor backfill() to collect all parsed docs then call addMany()
  in one shot instead of looping upsert() per document

https://claude.ai/code/session_01827GtuFKera7mFzToUDVTg